### PR TITLE
Make cl-quakeinfo work correctly and portably

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ display information about recent earthquakes.
 
 I found that the USGS website has hourly, daily and weekly quake data
 available
-[here](http://earthquake.usgs.gov/eqcenter/recenteqsww/catalogs/).
+[here](http://earthquake.usgs.gov/earthquakes/catalogs/).
 
 Possible formats of interest are XML (RSS) and CSV.  I decided to
 use the CSV format, comma separated files, since XML seemed like
@@ -70,7 +70,7 @@ quakes.  2.0 means those larger than magnitude 2.0.
 ## Installation
 
 You need to download and install cl-geocode and cl-quakeinfo and to
-register, with ASDF, the *.asd* files.  Then, you just need to:
+register, with ASDF, the *.asd files.  Then, you just need to:
 
     cl-user(1): (asdf:load-system :usgs)
     ; loading system definition from /home/layer/src/usgs/usgs.asd into
@@ -99,9 +99,10 @@ register, with ASDF, the *.asd* files.  Then, you just need to:
       :within 1.0)
     t
 
-Don't forget to set your Google Maps API key:
+If you have one, don't forget to set your Google Maps API key:
 
     cl-user(2): (setq cl-geocode:*default-key* "...")
 
 where what is in the quotes is the API key you obtained from Google.
 See the instructions in cl-geocode for more information.
+NB: Not necessary with the new Google Maps API version 3.

--- a/cl-quakeinfo.asd
+++ b/cl-quakeinfo.asd
@@ -1,23 +1,11 @@
-
-(in-package :cl-user)
-
-(defclass cl-quakeinfo-source-file (asdf:cl-source-file) ())
-
-(defmethod asdf:source-file-type ((f cl-quakeinfo-source-file) (m asdf:module))
-  (declare (ignorable f m))
-  "cl")
-
-(asdf:disable-output-translations)
-
-(cond
- (asdf:*central-registry*
-  (push #p"../cl-geocode/" asdf:*central-registry*))
- (t
-  (setf asdf:*central-registry*
-    '(*default-pathname-defaults*
-      #p"../cl-geocode/"))))
-
-(asdf:defsystem cl-quakeinfo
-    :default-component-class cl-quakeinfo-source-file
-    :components ((:file "cl-quakeinfo"))
-    :depends-on ("cl-geocode"))
+(defsystem "cl-quakeinfo"
+  :depends-on
+  ("cl-geocode"
+   "uiop"
+   (:feature (:not :allegro) "acl-compat")
+   (:feature (:not :allegro) "cl-ppcre")
+   (:feature (:not :allegro) "cl-date-time-parser")
+   (:feature :allegro (:require "regexp2"))
+   (:feature :allegro (:require "datetime"))
+   (:feature :allegro (:require "aserve")))
+  :components ((:file "cl-quakeinfo" :type "cl")))

--- a/cl-quakeinfo.cl
+++ b/cl-quakeinfo.cl
@@ -5,22 +5,18 @@
 ;; (http://opensource.franz.com/preamble.html),
 ;; known as the LLGPL.
 
-(eval-when (compile eval load)
-  #+allegro (require :regexp2)
-  #+allegro (require :datetime)
-  #+allegro (require :aserve) ;; for http-copy-file
-  (use-package :cl-geocode))
+(defpackage :cl-quakeinfo
+  (:use :common-lisp :cl-geocode #+allegro :excl #-allegro acl-compat.excl))
 
-(in-package :cl-user)
+(in-package :cl-quakeinfo)
 
 ;; See
 ;;  http://earthquake.usgs.gov/earthquakes/feed/v1.0/csv.php
 ;; for more information.
-(defvar *usgs-gov-url-prefix* 
-    "http://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/")
+(defparameter *usgs-gov-url-prefix*
+  "http://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/")
 
-(defvar *quake-info-re* nil)
-(setq *quake-info-re*
+(defparameter *quake-info-re*
   (let ((re (concatenate 'simple-string
 	      "^"
 	      "([^,]+),"		;ISO 8601 date/time
@@ -51,28 +47,24 @@
 	      (:day  "all_day.csv")
 	      (:hour "all_hour.csv")
 	      (t (error "bad period: ~s." period)))))
-  
+
   (and (probe-file temp-file) (ignore-errors (delete-file temp-file)))
   (when verbose
     (format t ";; Downloading quake data...")
     (force-output))
   #+allegro (net.aserve.client:http-copy-file url temp-file)
-  #+sbcl
-  (let ((p (run-program "/usr/bin/curl" (list "-L" url "-o" temp-file)
-			:wait t)))
-    (when (not (zerop (process-exit-code p)))
-      (error "Failed to retrieve data via curl.  Exit code ~d."
-	     (process-exit-code p))))
-  (when verbose
-    (format t "done.~%")
-    (force-output))
-  
+  #-allegro
+  (with-open-file (s temp-file :direction :output :element-type 'character)
+    (write-sequence (drakma:http-request url :method :get) s))
+  (format t "done.~%")
+  (force-output)
+
   (let (header-line line lines location
 	date latitude longitude magnitude)
     (unwind-protect
 	(with-open-file (s temp-file)
 	  ;; This trick only works on UNIX:
-	  #-mswindows (delete-file temp-file)
+	  #-os-windows (delete-file temp-file)
 	  (setq header-line (read-line s nil s))
 	  (when (eq header-line s) (error "no header?"))
 	  (tagbody
@@ -81,9 +73,9 @@
 	    (when (eq line s)
 	      (return-from get-quake-info
 		(nreverse lines)))
-	    #+sbcl
+	    #-allegro
 	    (multiple-value-bind (found res-vec)
-		(cl-ppcre:scan-to-strings re line)
+		(cl-ppcre:scan-to-strings *quake-info-re* line)
 	      (when (not found)
 		(warn "couldn't parse line: ~a~%" line)
 		(go top))
@@ -103,7 +95,7 @@
 		    latitude xlatitude
 		    longitude xlongitude
 		    magnitude xmagnitude))
-	    
+
 	    (setq latitude
 	      (or (ignore-errors (read-from-string latitude))
 		  (error "bad latitude: ~s" latitude)))
@@ -137,19 +129,23 @@
 			      magnitude)
 			lines))))
 	    (go top)))
-      #+mswindows (delete-file temp-file))))
+      #+os-windows (delete-file temp-file))))
 
 (defun quake-date-to-ut (date)
+  #+allegro
   (truncate
    ;; quake data, apparently, is to fractional seconds
-   (util.date-time:date-time-to-ut (util.date-time:date-time date))))
+   (util.date-time:date-time-to-ut (util.date-time:date-time date)))
+  #-allegro
+  (cl-date-time-parser:parse-date-time date))
 
-#+allegro
-(setq *global-gc-behavior* :auto) ;; get rid of GC related messages
+;; TODO: move this somewhere else
+#+allegro (setq excl:*global-gc-behavior* :auto) ;; get rid of GC related messages
 
-(format t ";; Try this:~%")
-(pprint
- '(get-quake-info
-   (place-to-location "Oakland, CA")
-   :period :week
-   :larger-than nil :within 1.0))
+(let ((*package* (find-package :common-lisp))
+      (*print-pretty* t))
+  (format t ";; Try this:~%~W~%"
+          '(get-quake-info
+            (place-to-location "Oakland, CA")
+            :period :week :larger-than nil :within 1.0))
+  (finish-output))

--- a/cl-quakeinfo.cl
+++ b/cl-quakeinfo.cl
@@ -33,8 +33,8 @@
 			    (period :week)
 			    (within
 			     ;; distance in decimal degrees
-			     3.0)
-			    (larger-than 1.0)
+			     3.0f0)
+			    (larger-than 1.0f0)
 			    (temp-file "/tmp/quakeinfo.txt")
 			    filter
 			    convert-date
@@ -60,7 +60,8 @@
   (force-output)
 
   (let (header-line line lines location
-	date latitude longitude magnitude)
+	date latitude longitude magnitude
+        (*read-default-float-format* 'single-float))
     (unwind-protect
 	(with-open-file (s temp-file)
 	  ;; This trick only works on UNIX:
@@ -147,5 +148,5 @@
   (format t ";; Try this:~%~W~%"
           '(get-quake-info
             (place-to-location "Oakland, CA")
-            :period :week :larger-than nil :within 1.0))
+            :period :week :larger-than nil :within 1.0f0))
   (finish-output))

--- a/test.cl
+++ b/test.cl
@@ -18,12 +18,12 @@
  (get-quake-info (place-to-location "Oakland, CA")
 		 :period :week
 		 :larger-than nil
-		 :within 1.0))
+		 :within 1.0f0))
 (pprint
  (get-quake-info (place-to-location "Oakland, CA")
 		 :period :week
 		 :convert-date t
 		 :larger-than nil
-		 :within 1.0))
+		 :within 1.0f0))
 
 (exit 0)


### PR DESCRIPTION
Note that this relies on my patches to cl-geocode, at https://github.com/kraison/cl-geocode/pull/1 themselves based on kraison's fork to your repository.
